### PR TITLE
Account, Team, Apply, Invite API 설계 (일부 수정)

### DIFF
--- a/src/main/java/com/ksu/soccerserver/account/Account.java
+++ b/src/main/java/com/ksu/soccerserver/account/Account.java
@@ -41,6 +41,4 @@ public class Account {
     public void updateMyInfo(String name) { this.name = name; }
 
     public void joinTeam(Team team) { this.team = team; }
-
-    public void withdrawalTeam() { this.team = null; }
 }

--- a/src/main/java/com/ksu/soccerserver/account/AccountController.java
+++ b/src/main/java/com/ksu/soccerserver/account/AccountController.java
@@ -4,6 +4,7 @@ package com.ksu.soccerserver.account;
 import com.ksu.soccerserver.team.Team;
 import com.ksu.soccerserver.team.TeamRepository;
 import lombok.RequiredArgsConstructor;
+import org.apache.catalina.webresources.JarResourceRoot;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -62,7 +63,9 @@ public class AccountController {
     // 회원 탈퇴
     @DeleteMapping("/{accountId}")
     public ResponseEntity<?> deleteAccount(@PathVariable Long accountId){
-        accountRepository.deleteById(accountId);
+        Account findAccount = accountRepository.findById(accountId).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."));
+
+        accountRepository.delete(findAccount);
 
         return new ResponseEntity<>("회원탈퇴 완료", HttpStatus.OK);
     }
@@ -71,7 +74,9 @@ public class AccountController {
     @PutMapping("/{accountId}/withdrawal/{teamId}")
     public ResponseEntity<?> withdrawalTeam(@PathVariable Long accountId, @PathVariable Long teamId) {
         Account findAccount = accountRepository.findById(accountId).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."));
-        findAccount.withdrawalTeam();
+        Team findTeam = teamRepository.findById(teamId).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."));
+
+        findTeam.getAccounts().remove(findAccount);
 
         accountRepository.save(findAccount);
 

--- a/src/main/java/com/ksu/soccerserver/apply/Apply.java
+++ b/src/main/java/com/ksu/soccerserver/apply/Apply.java
@@ -28,13 +28,6 @@ public class Apply {
     @ManyToOne
     private Team team;
 
-    public void joinApply(Account account, Team team){
-        this.account = account;
-        this.team = team;
-        this.applyStatus = ApplyStatus.APPLY_PENDING;
-    }
 
-    public void updateStatus(ApplyStatus applyStatus){
-        this.applyStatus = applyStatus;
-    }
+    //TODO 신청에 대한 상태변화 메소드는 상의 후 설계
 }

--- a/src/main/java/com/ksu/soccerserver/apply/ApplyController.java
+++ b/src/main/java/com/ksu/soccerserver/apply/ApplyController.java
@@ -45,12 +45,12 @@ public class ApplyController {
     }
 
 //  가입신청삭제 (DELETE)
-    @DeleteMapping("/accounts/{accountId}/{applyId}")
-    public ResponseEntity<?> deleteApply(@PathVariable Long accountId, @PathVariable Long applyId) {
+    @DeleteMapping("/accounts/{applyId}")
+    public ResponseEntity<?> deleteApply( @PathVariable Long applyId) {
 
         Apply apply = applyRepository.findById(applyId).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No_Found_Apply"));
-        apply.updateStatus(ApplyStatus.APPLY_CANCEL);
-        applyRepository.deleteById(applyId);
+
+        applyRepository.delete(apply);
 
         return new ResponseEntity<>("Success delete", HttpStatus.OK);
     }
@@ -65,15 +65,5 @@ public class ApplyController {
         return new ResponseEntity<>(appliesMember, HttpStatus.OK);
     }
 
-//  가입신청을 받은 팀이 해당 요청에 대하여 수락, 거절 등의 이벤트 api 프론트와 상의 후 진행
-//    @PutMapping("/teams/{teamId}/{applyId}")
-//    public ResponseEntity<?> updateApplyStatus(@PathVariable Long teamId, @PathVariable Long applyId) {
-//
-//        Apply apply = applyRepository.findById(applyId).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No_Found_Apply"));
-//
-//        apply.updateStatus(ApplyStatus.APPLY_ACCEPT); // 가입신청수락
-//        apply.updateStatus(ApplyStatus.APPLY_REJECT); // 가입신청거절
-//
-//        return new ResponseEntity<>(apply, HttpStatus.OK);
-//    }
+//  TODO 가입신청을 받은 팀이 해당 요청에 대하여 수락, 거절 등의 이벤트 api 프론트와 상의 후 진행
 }

--- a/src/main/java/com/ksu/soccerserver/invite/Invite.java
+++ b/src/main/java/com/ksu/soccerserver/invite/Invite.java
@@ -28,8 +28,5 @@ public class Invite {
     @ManyToOne
     private Team team;
 
-
-    public void updateStatus(InviteStatus inviteStatus){
-        this.inviteStatus = inviteStatus;
-    }
+    //TODO 신청에 대한 상태변화 메소드는 상의 후 설계
 }

--- a/src/main/java/com/ksu/soccerserver/invite/InviteController.java
+++ b/src/main/java/com/ksu/soccerserver/invite/InviteController.java
@@ -45,11 +45,9 @@ public class InviteController {
     }
 
     //    가입신청삭제 (DELETE)
-    @DeleteMapping("/teams/{teamId}/{inviteId}")
-    public ResponseEntity<?> deleteApply(@PathVariable Long teamId, @PathVariable Long inviteId) {
-
+    @DeleteMapping("/teams/{inviteId}")
+    public ResponseEntity<?> deleteApply(@PathVariable Long inviteId) {
         Invite invite = inviteRepository.findById(inviteId).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No_Found_Invite"));
-        invite.updateStatus(InviteStatus.INVITE_CANCEL);
 
         inviteRepository.deleteById(inviteId);
 
@@ -66,15 +64,6 @@ public class InviteController {
         return new ResponseEntity<>(appliesMember, HttpStatus.OK);
     }
 
-    //  자신에게 가입요청을 한 팀에 대하여 수락, 거절 등의 이벤트 api 프론트와 상의 후 진행
-//    @PutMapping("/accounts/{accountId}/{inviteId}")
-//    public ResponseEntity<?> updateApplyStatus(@PathVariable Long accountId, @PathVariable Long inviteId) {
-//
-//        Invite invite = inviteRepository.findById(inviteId).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No_Found_Invite"));
-//
-//        invite.updateStatus(InviteStatus.INVITE_ACCEPT); // 가입요청수락
-//        invite.updateStatus(InviteStatus.INVITE_REJECT); // 가입신청거절
-//
-//        return new ResponseEntity<>(invite, HttpStatus.OK);
-//    }
+    // TODO 자신에게 가입요청을 한 팀에 대하여 수락, 거절 등의 이벤트 api 프론트와 상의 후 진행
+
 }

--- a/src/main/java/com/ksu/soccerserver/team/TeamController.java
+++ b/src/main/java/com/ksu/soccerserver/team/TeamController.java
@@ -29,10 +29,12 @@ public class TeamController {
 
     // 생성되어 있는 모든 팀 GET
     @GetMapping
-    public ResponseEntity getTeams(){
+    public ResponseEntity<?> getTeams(){
         List<Team> teams = teamRepository.findAll();
 
-        return new ResponseEntity(teams, HttpStatus.OK);
+        if (teams.isEmpty()) { return new ResponseEntity<>("생성된 팀이 없습니다.", HttpStatus.NOT_FOUND); }
+
+        return new ResponseEntity<>(teams, HttpStatus.OK);
     }
 
     // 해당 teamId를 가진 팀 GET
@@ -66,7 +68,9 @@ public class TeamController {
     // 팀 삭제
     @DeleteMapping("/{teamId}")
     public ResponseEntity<?> deleteTeam(@PathVariable Long teamId) {
-        teamRepository.deleteById(teamId);
+        Team findTeam = teamRepository.findById(teamId).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 팀입니다."));
+
+        teamRepository.delete(findTeam);
 
         return new ResponseEntity<>("Team Delete Success", HttpStatus.OK);
     }


### PR DESCRIPTION
##AccountController
-회원탈퇴 : accountId null-check
-팀탈퇴 : teamId로 team을 검색, accountId로 account를 검색하여 삭제 메소드 변경

##TeamController
-AccountRepository : 추후를 대비하여 보존
-모든 팀 GET : ResponseEntity -> ResponseEntity<> 로 변경
-팀 삭제 : null-check

##Apply
-Line(31) : 불필요 메서드 삭제

##ApplyController
-가입 신청 삭제 : 사용하지 않는 accountId 삭제, apply 객체를 지우는 방향으로 우선 설계
-Line(68) : 코드삭제 및 TODO 주석 추가

##InviteController
-가입 신청 삭제 : 사용하지 않는 teamId 삭제, invite 객체를 지우는 방향으로 우선 설계
-Line(69) : 코드삭제 및 TODO 주석 추가

