### PR TITLE
account, find, auth 패키지 구조 및 ClassName 변경

### DIFF
--- a/src/main/java/com/ksu/soccerserver/account/AccountService.java
+++ b/src/main/java/com/ksu/soccerserver/account/AccountService.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service
-public class AccountDetailsService implements UserDetailsService {
+public class AccountService implements UserDetailsService {
 
     private final AccountRepository accountRepository;
 

--- a/src/main/java/com/ksu/soccerserver/account/LogoutAccountRepository.java
+++ b/src/main/java/com/ksu/soccerserver/account/LogoutAccountRepository.java
@@ -1,9 +1,0 @@
-package com.ksu.soccerserver.account;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.Optional;
-
-public interface LogoutAccountRepository extends JpaRepository<LogoutAccount, Long> {
-    Optional<LogoutAccount> findByToken(String token);
-}

--- a/src/main/java/com/ksu/soccerserver/auth/AuthController.java
+++ b/src/main/java/com/ksu/soccerserver/auth/AuthController.java
@@ -1,13 +1,11 @@
-package com.ksu.soccerserver.account;
+package com.ksu.soccerserver.auth;
 
+import com.ksu.soccerserver.account.Account;
+import com.ksu.soccerserver.account.AccountRepository;
 import com.ksu.soccerserver.config.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,10 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
-import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
-import java.util.Collections;
-import java.util.Optional;
 
 @RequestMapping("/api")
 @RequiredArgsConstructor
@@ -29,7 +24,7 @@ public class AuthController {
     private final AccountRepository accountRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
-    private final LogoutAccountRepository logoutAccountRepository;
+    private final ExpiredTokenRepository expiredTokenRepository;
     //DB에서 사용자 인증정보를 가져오는 객체
     //private final UserDetailsService userDetailsService = null; //?
     private final UserDetailsService userDetailsService;
@@ -49,7 +44,7 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseEntity<?> logout(HttpServletRequest req) {
         String token = req.getHeader("X-AUTH-TOKEN");
-        logoutAccountRepository.save(LogoutAccount.builder().token(token).build());
+        expiredTokenRepository.save(ExpiredToken.builder().token(token).build());
         return new ResponseEntity<>("", HttpStatus.OK);
     }
 }

--- a/src/main/java/com/ksu/soccerserver/auth/ExpiredToken.java
+++ b/src/main/java/com/ksu/soccerserver/auth/ExpiredToken.java
@@ -1,4 +1,4 @@
-package com.ksu.soccerserver.account;
+package com.ksu.soccerserver.auth;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,7 +13,7 @@ import javax.persistence.*;
 @Table
 @Getter
 @NoArgsConstructor  @AllArgsConstructor
-public class LogoutAccount {
+public class ExpiredToken {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/ksu/soccerserver/auth/ExpiredTokenRepository.java
+++ b/src/main/java/com/ksu/soccerserver/auth/ExpiredTokenRepository.java
@@ -1,0 +1,9 @@
+package com.ksu.soccerserver.auth;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ExpiredTokenRepository extends JpaRepository<ExpiredToken, Long> {
+    Optional<ExpiredToken> findByToken(String token);
+}

--- a/src/main/java/com/ksu/soccerserver/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ksu/soccerserver/config/JwtAuthenticationFilter.java
@@ -1,6 +1,6 @@
 package com.ksu.soccerserver.config;
 
-import com.ksu.soccerserver.account.LogoutAccountRepository;
+import com.ksu.soccerserver.auth.ExpiredTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -17,14 +17,14 @@ import java.io.IOException;
 //검증이 끝난 JWT로부터 유저정보를 받아와 UsernamePasswordAuthenticationFilter로 전달
 public class JwtAuthenticationFilter extends GenericFilterBean {
     private final JwtTokenProvider jwtTokenProvider;
-    private final LogoutAccountRepository logoutAccountRepository;
+    private final ExpiredTokenRepository expiredTokenRepository;
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         //헤더에서 JWT를 받아온다.
         String token = jwtTokenProvider.resolveToken((HttpServletRequest) request);
 
-        if (token != null && !logoutAccountRepository.findByToken(token).isPresent() && jwtTokenProvider.validateToken(token)) {
+        if (token != null && !expiredTokenRepository.findByToken(token).isPresent() && jwtTokenProvider.validateToken(token)) {
             //토큰이 유효하면 토큰으로부터 유저 정보 받아온다.
             Authentication authentication = jwtTokenProvider.getAuthentication(token);
             //SecurityContext에 Authentication 객체 저장

--- a/src/main/java/com/ksu/soccerserver/config/SecurityConfig.java
+++ b/src/main/java/com/ksu/soccerserver/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package com.ksu.soccerserver.config;
 
-import com.ksu.soccerserver.account.LogoutAccountRepository;
+import com.ksu.soccerserver.auth.ExpiredTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpStatus;
@@ -21,7 +21,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     private final JwtTokenProvider jwtTokenProvider;
-    private final LogoutAccountRepository logoutAccountRepository;
+    private final ExpiredTokenRepository expiredTokenRepository;
 
     //Bean - Spring FW를 통해 생성되고 관리되는 객체
     //암호화에 필요한 PasswordEncoder를 Bean등록한다.
@@ -65,7 +65,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/h2-console/**").permitAll() //개발 편의상 permitAll
                 .and().headers().frameOptions().disable()
                 .and()
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, logoutAccountRepository), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, expiredTokenRepository), UsernamePasswordAuthenticationFilter.class)
                 //JwtAuthenticationFilter를 UserPasswordAuthenticationFilter전에 넣는다.
                 .exceptionHandling().authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED));
     }

--- a/src/main/java/com/ksu/soccerserver/find/FindController.java
+++ b/src/main/java/com/ksu/soccerserver/find/FindController.java
@@ -1,5 +1,7 @@
-package com.ksu.soccerserver.account;
+package com.ksu.soccerserver.find;
 
+import com.ksu.soccerserver.account.Account;
+import com.ksu.soccerserver.account.AccountRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;


### PR DESCRIPTION
**1. account 패키지**
 - accountDetailsService -> AccountService로 이름 변경

**2. find 패키지 생성**
 - soccer-server/account/FindController.java
   => soccer-server/find/FindController.java

**3. auth 패키지 생성 및 클래스 이름 변경**
 - soccer-server/account/AuthController.java
  => soccer-server/account/AuthController.java
 - soccer-server/account/LogoutAccount.java
  =>  soccer-server/account/ExpiredToken.java
 - soccer-server/account/LogoutAccountRepository.java
  =>  soccer-server/account/ExpiredTokenRepository.java