### PR TITLE
modify TeamDTO & delete leadingTeam of Account

### DIFF
--- a/src/main/java/com/ksu/soccerserver/account/Account.java
+++ b/src/main/java/com/ksu/soccerserver/account/Account.java
@@ -63,14 +63,13 @@ public class Account {
     @Column
     private String district;
 
+    private boolean isOwner = false;
+
     @OneToMany(mappedBy = "account")
     private final Set<ApplicationAccount> apply = new HashSet<>();
 
     @ManyToOne
     private Team team;
-
-    @OneToOne
-    Team leadingTeam;
 
     @ElementCollection(fetch = FetchType.EAGER)
     @Builder.Default
@@ -90,9 +89,10 @@ public class Account {
 
     public void changePW(String password) { this.password = password;}
 
-    public void setLeadingTeam(Team team) { this.leadingTeam = team; }
-
     public void setTeam(Team team) { this.team = team; }
+    public void setTeam() { this.team = null; }
+
+    public void setOwner(){ this.isOwner = true; }
 
     public void withdrawTeam() { this.team = null;}
 

--- a/src/main/java/com/ksu/soccerserver/account/dto/AccountResponse.java
+++ b/src/main/java/com/ksu/soccerserver/account/dto/AccountResponse.java
@@ -1,7 +1,6 @@
 package com.ksu.soccerserver.account.dto;
 
 import com.ksu.soccerserver.account.Account;
-import com.sun.istack.Nullable;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -21,8 +20,8 @@ public class AccountResponse {
     private String weight;
     private String height;
     private String foot;
+    private boolean isOwner;
     private AccountTeamDTO team;
-    private AccountTeamDTO leadingTeam;
 
     public AccountResponse(Account account) {
         this.id = account.getId();
@@ -38,10 +37,9 @@ public class AccountResponse {
         this.weight = account.getWeight();
         this.height = account.getHeight();
         this.foot = account.getFoot();
+        this.isOwner = account.isOwner();
         if(account.getTeam()!=null){
             this.team = new AccountTeamDTO(account.getTeam());
-            this.leadingTeam = new AccountTeamDTO(account.getLeadingTeam());
         }
-
     }
 }

--- a/src/main/java/com/ksu/soccerserver/match/MatchController.java
+++ b/src/main/java/com/ksu/soccerserver/match/MatchController.java
@@ -40,16 +40,14 @@ public class MatchController {
             matchResponses = matchRepository.findAllByMatchStatus(MatchStatus.PENDING)
                     .stream()
                     .filter(match -> match.getHomeTeam().getName().contains(teamName))
-                    .map(match ->
-                            new MatchResponse(match))
+                    .map(match -> new MatchResponse(match))
                     .collect(Collectors.toList());
         } else if ("All".equals(district)){
             matchResponses = matchRepository.findAllByMatchStatus(MatchStatus.PENDING)
                     .stream()
                     .filter(match -> match.getHomeTeam().getName().contains(teamName)
                         && match.getState().equals(state))
-                    .map(match ->
-                            new MatchResponse(match))
+                    .map(match -> new MatchResponse(match))
                     .collect(Collectors.toList());
         } else {
             matchResponses = matchRepository.findAllByMatchStatus(MatchStatus.PENDING)
@@ -57,8 +55,7 @@ public class MatchController {
                     .filter(match -> match.getHomeTeam().getName().contains(teamName)
                         && match.getState().equals(state)
                         && match.getDistrict().equals(district))
-                    .map(match ->
-                            new MatchResponse(match))
+                    .map(match -> new MatchResponse(match))
                     .collect(Collectors.toList());
         }
         return new ResponseEntity<>(matchResponses, HttpStatus.OK);
@@ -125,7 +122,7 @@ public class MatchController {
     public ResponseEntity<?> createMatch(@RequestBody MatchCreateRequest matchCreateRequest,
                                          @CurrentAccount Account nowAccount){
 
-        Team homeTeam = teamRepository.findById(nowAccount.getLeadingTeam().getId())
+        Team homeTeam = teamRepository.findById(nowAccount.getTeam().getId())
                 .orElseThrow(()-> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 팀입니다."));
 
         if(homeTeam.getOwner().getId().equals(nowAccount.getId())) {
@@ -137,7 +134,7 @@ public class MatchController {
 
             return new ResponseEntity<>(response, HttpStatus.CREATED);
         } else{
-            return new ResponseEntity<>("해당 유저는 팀팀장이 아닙니다.", HttpStatus.BAD_REQUEST);
+            return new ResponseEntity<>("해당 유저는 팀장이 아닙니다.", HttpStatus.BAD_REQUEST);
         }
     }
 

--- a/src/main/java/com/ksu/soccerserver/team/dto/TeamDTO.java
+++ b/src/main/java/com/ksu/soccerserver/team/dto/TeamDTO.java
@@ -54,7 +54,6 @@ public class TeamDTO {
         this.description = team.getDescription();
         this.owner = new TeamsAccountDTO(team.getOwner());
         this.accounts = new TeamsAccountsDTO(accounts);
-        this.isOwner = true;
         this.applies = applies;
     }
 }


### PR DESCRIPTION
#71 의 1번문제 해결

원인 : 가입 수락시 
`if(account.getTeam()!=null){  
            this.team = new AccountTeamDTO(account.getTeam());
            this.leadingTeam = new AccountTeamDTO(account.getLeadingTeam());
}`   

해당 코드로 인해 leadingTeam이 null로 객체를 만들어 error 발생

해결 : 불필요한 LeadingTeam 삭제로
`this.leadingTeam = new AccountTeamDTO(account.getLeadingTeam());` 삭제

---  
Account에 팀장판별유무값으로 isOwner(boolean) 추가
따라서 TeamDTO의 isOwner삭제